### PR TITLE
Add precision output option

### DIFF
--- a/grc/filerepeater_VectorToTxtFile.xml
+++ b/grc/filerepeater_VectorToTxtFile.xml
@@ -4,7 +4,7 @@
   <key>filerepeater_VectorToTxtFile</key>
   <category>[Advanced File]</category>
   <import>import filerepeater</import>
-  <make>filerepeater.VectorToTxtFile($filename, $vectorsize, $frequency, $sampleRate, $notes, $append, $updateRateSec, $WriteTimeHeader)</make>
+  <make>filerepeater.VectorToTxtFile($filename, $vectorsize, $frequency, $sampleRate, $notes, $append, $updateRateSec, $precision, $WriteTimeHeader)</make>
 	<param>
 		<name>File</name>
 		<key>filename</key>
@@ -45,6 +45,13 @@
 		<key>updateRateSec</key>
 		<value>30.0</value>
 		<type>float</type>
+	</param>
+	
+	<param>
+		<name>Output Precision</name>
+		<key>precision</key>
+		<value>2</value>
+		<type>int</type>
 	</param>
 
 	<param>

--- a/include/filerepeater/VectorToTxtFile.h
+++ b/include/filerepeater/VectorToTxtFile.h
@@ -703,7 +703,7 @@ namespace gr {
        * class. filerepeater::VectorToTxtFile::make is the public interface for
        * creating new instances.
        */
-      static sptr make(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, bool WriteTimeHeader);
+      static sptr make(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, int precision, bool WriteTimeHeader);
     };
 
   } // namespace filerepeater

--- a/lib/VectorToTxtFile_impl.cc
+++ b/lib/VectorToTxtFile_impl.cc
@@ -686,16 +686,16 @@ namespace gr {
   namespace filerepeater {
 
     VectorToTxtFile::sptr
-    VectorToTxtFile::make(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, bool WriteTimeHeader)
+    VectorToTxtFile::make(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, int precision, bool WriteTimeHeader)
     {
       return gnuradio::get_initial_sptr
-        (new VectorToTxtFile_impl(filename, vectorLen, frequency, sampleRate, notes, append, updateRateSec, WriteTimeHeader));
+        (new VectorToTxtFile_impl(filename, vectorLen, frequency, sampleRate, notes, append, updateRateSec, precision, WriteTimeHeader));
     }
 
     /*
      * The private constructor
      */
-    VectorToTxtFile_impl::VectorToTxtFile_impl(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, bool WriteTimeHeader)
+    VectorToTxtFile_impl::VectorToTxtFile_impl(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, int precision, bool WriteTimeHeader)
       : gr::sync_block("VectorToTxtFile",
               gr::io_signature::make(1, 1, sizeof(float)*vectorLen),
               gr::io_signature::make(0, 0, 0))
@@ -707,6 +707,7 @@ namespace gr {
 		d_notes = notes;
 		d_append = append;
 		d_updateRateSec = updateRateSec;
+		d_precision = precision;
 		d_writeTimeHeader = WriteTimeHeader;
 
 	    lastUpdateTime = std::chrono::steady_clock::now();
@@ -827,9 +828,9 @@ namespace gr {
 
 				for (int i=0;i<d_vectorLen;i++) {
 					if (i < (d_vectorLen-1))
-						fprintf(d_fp,"%f,",in[i]);
+						fprintf(d_fp,"%.*f,", d_precision, in[i]);
 					else {
-						fprintf(d_fp,"%f\n",in[i]);
+						fprintf(d_fp,"%.*f,", d_precision, in[i]);
 					}
 				}
 			}

--- a/lib/VectorToTxtFile_impl.h
+++ b/lib/VectorToTxtFile_impl.h
@@ -697,6 +697,7 @@ namespace gr {
 		string d_notes;
 		bool d_append;
 		float d_updateRateSec;
+		int d_precision;
 		bool d_writeTimeHeader;
 
    	 	std::chrono::time_point<std::chrono::steady_clock> lastUpdateTime;
@@ -711,7 +712,7 @@ namespace gr {
     	string setTwoDigit(string& numStr);
 
      public:
-      VectorToTxtFile_impl(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, bool WriteTimeHeader);
+      VectorToTxtFile_impl(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, int precision, bool WriteTimeHeader);
       ~VectorToTxtFile_impl();
 
       virtual bool stop();


### PR DESCRIPTION
Add precision output option. 

Fixes https://github.com/ghostop14/gr-filerepeater/issues/4 for the maint-3.7 branch