### PR TITLE
Add precision output option for 3.8 branch, fix vlen and swig

### DIFF
--- a/grc/filerepeater_VectorToTxtFile.block.yml
+++ b/grc/filerepeater_VectorToTxtFile.block.yml
@@ -28,6 +28,10 @@ parameters:
     label: Update Rate (sec)
     dtype: float
     default: '30.0'
+-   id: precision
+    label: Output Precision
+    dtype: int
+    default: '2'
 -   id: append
     label: Append To File
     dtype: enum
@@ -47,7 +51,7 @@ inputs:
 templates:
     imports: import filerepeater
     make: filerepeater.VectorToTxtFile(${filename}, ${vectorsize}, ${frequency}, ${sampleRate},
-        ${notes}, ${append}, ${updateRateSec}, ${WriteTimeHeader})
+        ${notes}, ${append}, ${updateRateSec}, ${precision}, ${WriteTimeHeader})
 
 documentation: |-
     This block will take a float vector and write it as a comma-separated entry in the specified text file.  Frequency, sample rate, and any desired notes will be added before the first sample.  An optional runtime header can be added before each row in append mode to track how far into a sequence the specific vector is.

--- a/grc/filerepeater_VectorToTxtFile.block.yml
+++ b/grc/filerepeater_VectorToTxtFile.block.yml
@@ -12,7 +12,7 @@ parameters:
     label: Vector Size
     dtype: int
     default: '1024'
-    hide: ${ 'part' if vlen == 1 else 'none' }
+    hide: 'none'
 -   id: frequency
     label: Frequency
     dtype: float

--- a/include/filerepeater/VectorToTxtFile.h
+++ b/include/filerepeater/VectorToTxtFile.h
@@ -703,7 +703,7 @@ namespace gr {
        * class. filerepeater::VectorToTxtFile::make is the public interface for
        * creating new instances.
        */
-      static sptr make(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, bool WriteTimeHeader);
+      static sptr make(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, int precision, bool WriteTimeHeader);
     };
 
   } // namespace filerepeater

--- a/lib/VectorToTxtFile_impl.cc
+++ b/lib/VectorToTxtFile_impl.cc
@@ -686,16 +686,16 @@ namespace gr {
   namespace filerepeater {
 
     VectorToTxtFile::sptr
-    VectorToTxtFile::make(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, bool WriteTimeHeader)
+    VectorToTxtFile::make(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, int precision, bool WriteTimeHeader)
     {
       return gnuradio::get_initial_sptr
-        (new VectorToTxtFile_impl(filename, vectorLen, frequency, sampleRate, notes, append, updateRateSec, WriteTimeHeader));
+        (new VectorToTxtFile_impl(filename, vectorLen, frequency, sampleRate, notes, append, updateRateSec, precision, WriteTimeHeader));
     }
 
     /*
      * The private constructor
      */
-    VectorToTxtFile_impl::VectorToTxtFile_impl(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, bool WriteTimeHeader)
+    VectorToTxtFile_impl::VectorToTxtFile_impl(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, int precision, bool WriteTimeHeader)
       : gr::sync_block("VectorToTxtFile",
               gr::io_signature::make(1, 1, sizeof(float)*vectorLen),
               gr::io_signature::make(0, 0, 0))
@@ -707,6 +707,7 @@ namespace gr {
 		d_notes = notes;
 		d_append = append;
 		d_updateRateSec = updateRateSec;
+		d_precision = precision;
 		d_writeTimeHeader = WriteTimeHeader;
 
 	    lastUpdateTime = std::chrono::steady_clock::now();
@@ -827,9 +828,9 @@ namespace gr {
 
 				for (int i=0;i<d_vectorLen;i++) {
 					if (i < (d_vectorLen-1))
-						fprintf(d_fp,"%f,",in[i]);
+						fprintf(d_fp,"%.*f,", d_precision, in[i]);
 					else {
-						fprintf(d_fp,"%f\n",in[i]);
+						fprintf(d_fp,"%.*f,", d_precision, in[i]);
 					}
 				}
 			}

--- a/lib/VectorToTxtFile_impl.h
+++ b/lib/VectorToTxtFile_impl.h
@@ -697,6 +697,7 @@ namespace gr {
 		string d_notes;
 		bool d_append;
 		float d_updateRateSec;
+		int d_precision;
 		bool d_writeTimeHeader;
 
    	 	std::chrono::time_point<std::chrono::steady_clock> lastUpdateTime;
@@ -711,7 +712,7 @@ namespace gr {
     	string setTwoDigit(string& numStr);
 
      public:
-      VectorToTxtFile_impl(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, bool WriteTimeHeader);
+      VectorToTxtFile_impl(const char *filename, int vectorLen, float frequency, float sampleRate, const char *notes, bool append, float updateRateSec, int precision, bool WriteTimeHeader);
       ~VectorToTxtFile_impl();
 
       virtual bool stop();

--- a/swig/filerepeater_swig.i
+++ b/swig/filerepeater_swig.i
@@ -13,6 +13,7 @@
 #include "filerepeater/AdvFileSink.h"
 #include "filerepeater/file_repeater_ex.h"
 #include "filerepeater/flowsync.h"
+#include "filerepeater/VectorToTxtFile.h"
 %}
 
 %include "filerepeater/StateTimer.h"
@@ -25,3 +26,5 @@ GR_SWIG_BLOCK_MAGIC2(filerepeater, AdvFileSink);
 GR_SWIG_BLOCK_MAGIC2(filerepeater, file_repeater_ex);
 %include "filerepeater/flowsync.h"
 GR_SWIG_BLOCK_MAGIC2(filerepeater, flowsync);
+%include "filerepeater/VectorToTxtFile.h"
+GR_SWIG_BLOCK_MAGIC2(filerepeater, VectorToTxtFile);


### PR DESCRIPTION
This PR adds the precision output option for the Vector to Text file block.

Fixes a vlen hiding bug...might want to address that in a different way.

Fixes swig not finding this block headers.

Fixes: https://github.com/ghostop14/gr-filerepeater/issues/4 for the master/3.8 branch.

