### PR TITLE
Add YAML manifest, install examples, add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# In GNU Radio 3.9+, pybind11 compares hash values of headers and source
+# files against knowns values.  Conversion of values to CRLF on checkout
+# break those checks so keep LF values when files are subject to said checks
+#
+*.h    text eol=lf
+*.c    text eol=lf
+*.cc   text eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ add_custom_target(uninstall
 add_subdirectory(include/filerepeater)
 add_subdirectory(lib)
 add_subdirectory(apps)
+add_subdirectory(examples)
 add_subdirectory(docs)
 # NOTE: manually update below to use GRC to generate C++ flowgraphs w/o python
 if(ENABLE_PYTHON)
@@ -182,3 +183,7 @@ endif(ENABLE_PYTHON)
 install(FILES cmake/Modules/filerepeaterConfig.cmake
     DESTINATION ${CMAKE_MODULES_DIR}/filerepeater
 )
+
+install(FILES MANIFEST.yml
+    RENAME MANIFEST-${VERSION_MAJOR}.${VERSION_API}.${VERSION_ABI}${VERSION_PATCH}.yml
+    DESTINATION share/gnuradio/manifests/filerepeater)

--- a/MANIFEST.yml
+++ b/MANIFEST.yml
@@ -1,0 +1,23 @@
+title: The FILEREPEATER OOT Module
+version: 1.0
+brief: A set of GNURadio blocks with more control over how files are played
+tags: # Tags are arbitrary, but look at CGRAN what other authors are using
+  - files
+  - iq
+  - recording
+author:
+  - ghostop14 <ghostop14@gmail.com>
+copyright_owner:
+  - ghostop14
+license: GPL-3.0-or-later
+gr_supported_version:
+  - 3.7
+  - 3.8
+  - 3.9
+  - 3.10
+repo: https://github.com/ghostop14/gr-filerepeater
+website: https://github.com/ghostop14/gr-filerepeater
+#icon: # Put a URL to a square image here that will be used as an icon
+description: |-
+  A set of GNURadio blocks with more control over how files are played
+file_format: 1

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,10 @@
+install(
+    FILES sample_flow_sync.grc
+          sample_replay_from_file_with_repeat.grc
+          test_advsink.grc
+          test_stateAnd.grc
+          test_stateOr.grc
+          test_statetimer.grc
+          test_statetobool.grc
+          test_timeofday.grc
+    DESTINATION share/gnuradio/examples/filerepeater)


### PR DESCRIPTION
1. Add YAML manifest that gets installed and can be used by GRC-Qt OOT module browser
2. Install examples to directory that is discoverable by GRC-Qt examples browser
3. Add .gitattributes so checkouts on Windows had Unix-style line endings and thus the Python binding header hash check won't fail